### PR TITLE
Feature bjs2 7255 (пока без тестов)

### DIFF
--- a/src/main/java/faang/school/analytics/AnalyticsServiceApp.java
+++ b/src/main/java/faang/school/analytics/AnalyticsServiceApp.java
@@ -9,7 +9,7 @@ import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.context.annotation.Bean;
 
 @SpringBootApplication
-@EnableFeignClients("school.faang.analytics.client")
+@EnableFeignClients("faang.school.analytics.client")
 public class AnalyticsServiceApp {
     public static void main(String[] args) {
         new SpringApplicationBuilder(AnalyticsServiceApp.class)

--- a/src/main/java/faang/school/analytics/config/redis/RedisConfig.java
+++ b/src/main/java/faang/school/analytics/config/redis/RedisConfig.java
@@ -24,7 +24,7 @@ public class RedisConfig {
     private int port;
     @Value("${spring.data.redis.channel.mentorship_requested_channel.name}")
     private String mentorshipRequestedChannel;
-    @Value("${spring.data.redis.channel.post_view_event.name}")
+    @Value("${spring.data.redis.channel.post_view_event_channel.name}")
     private String postViewEventChannel;
 
     @Bean

--- a/src/main/java/faang/school/analytics/config/redis/RedisConfig.java
+++ b/src/main/java/faang/school/analytics/config/redis/RedisConfig.java
@@ -1,0 +1,61 @@
+package faang.school.analytics.config.redis;
+
+import faang.school.analytics.listener.PostViewEventListener;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.jedis.JedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.data.redis.listener.adapter.MessageListenerAdapter;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@RequiredArgsConstructor
+public class RedisConfig {
+    private final PostViewEventListener postViewEventListener;
+    @Value("${spring.data.redis.port}")
+    private int port;
+    @Value("${spring.data.redis.host}")
+    private String host;
+    @Value("${string.data.redis.chanel.post_view_event.name}")
+    private String postViewEventChanel;
+
+    @Bean
+    public JedisConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration config = new RedisStandaloneConfiguration(host, port);
+        return new JedisConnectionFactory(config);
+    }
+
+    @Bean
+    public ChannelTopic postViewEventTopic() {
+        return new ChannelTopic(postViewEventChanel);
+    }
+
+    @Bean
+    public MessageListenerAdapter postListener() {
+        return new MessageListenerAdapter(postViewEventListener);
+    }
+
+    @Bean
+    public RedisMessageListenerContainer redisMessageListenerContainer(RedisConnectionFactory connectionFactory) {
+        RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+        container.setConnectionFactory(connectionFactory);
+        container.addMessageListener(postListener(), postViewEventTopic());
+        return container;
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(connectionFactory);
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+        return redisTemplate;
+    }
+}

--- a/src/main/java/faang/school/analytics/config/redis/RedisConfig.java
+++ b/src/main/java/faang/school/analytics/config/redis/RedisConfig.java
@@ -23,23 +23,13 @@ public class RedisConfig {
     private int port;
     @Value("${spring.data.redis.host}")
     private String host;
-    @Value("${string.data.redis.chanel.post_view_event.name}")
+    @Value("${spring.data.redis.channel.post_view_event.name}")
     private String postViewEventChanel;
 
     @Bean
     public JedisConnectionFactory redisConnectionFactory() {
         RedisStandaloneConfiguration config = new RedisStandaloneConfiguration(host, port);
         return new JedisConnectionFactory(config);
-    }
-
-    @Bean
-    public ChannelTopic postViewEventTopic() {
-        return new ChannelTopic(postViewEventChanel);
-    }
-
-    @Bean
-    public MessageListenerAdapter postListener() {
-        return new MessageListenerAdapter(postViewEventListener);
     }
 
     @Bean
@@ -57,5 +47,15 @@ public class RedisConfig {
         redisTemplate.setKeySerializer(new StringRedisSerializer());
         redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
         return redisTemplate;
+    }
+
+    @Bean
+    public ChannelTopic postViewEventTopic() {
+        return new ChannelTopic(postViewEventChanel);
+    }
+
+    @Bean
+    public MessageListenerAdapter postListener() {
+        return new MessageListenerAdapter(postViewEventListener);
     }
 }

--- a/src/main/java/faang/school/analytics/config/redis/RedisConfig.java
+++ b/src/main/java/faang/school/analytics/config/redis/RedisConfig.java
@@ -24,7 +24,7 @@ public class RedisConfig {
     @Value("${spring.data.redis.host}")
     private String host;
     @Value("${spring.data.redis.channel.post_view_event.name}")
-    private String postViewEventChanel;
+    private String postViewEventChannel;
 
     @Bean
     public JedisConnectionFactory redisConnectionFactory() {
@@ -36,7 +36,7 @@ public class RedisConfig {
     public RedisMessageListenerContainer redisMessageListenerContainer(RedisConnectionFactory connectionFactory) {
         RedisMessageListenerContainer container = new RedisMessageListenerContainer();
         container.setConnectionFactory(connectionFactory);
-        container.addMessageListener(postListener(), postViewEventTopic());
+        container.addMessageListener(postViewEventListener(), postViewEventTopic());
         return container;
     }
 
@@ -45,17 +45,17 @@ public class RedisConfig {
         RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
         redisTemplate.setConnectionFactory(connectionFactory);
         redisTemplate.setKeySerializer(new StringRedisSerializer());
-        redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
         return redisTemplate;
     }
 
     @Bean
     public ChannelTopic postViewEventTopic() {
-        return new ChannelTopic(postViewEventChanel);
+        return new ChannelTopic(postViewEventChannel);
     }
 
     @Bean
-    public MessageListenerAdapter postListener() {
+    public MessageListenerAdapter postViewEventListener() {
         return new MessageListenerAdapter(postViewEventListener);
     }
 }

--- a/src/main/java/faang/school/analytics/dto/PostViewEvent.java
+++ b/src/main/java/faang/school/analytics/dto/PostViewEvent.java
@@ -1,0 +1,14 @@
+package faang.school.analytics.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+public class PostViewEvent {
+    private long receiverId;
+    private long actorId;
+    private LocalDateTime receivedAt;
+}

--- a/src/main/java/faang/school/analytics/dto/PostViewEvent.java
+++ b/src/main/java/faang/school/analytics/dto/PostViewEvent.java
@@ -1,14 +1,19 @@
 package faang.school.analytics.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
 @Data
 @Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class PostViewEvent {
-    private long receiverId;
-    private long actorId;
-    private LocalDateTime receivedAt;
+    private long postId;
+    private long authorId;
+    private long userId;
+    private LocalDateTime viewedAt;
 }

--- a/src/main/java/faang/school/analytics/listener/AbstractEventListener.java
+++ b/src/main/java/faang/school/analytics/listener/AbstractEventListener.java
@@ -1,0 +1,43 @@
+package faang.school.analytics.listener;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import faang.school.analytics.mapper.AnalyticsEventMapper;
+import faang.school.analytics.service.AnalyticsEventService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public abstract class AbstractEventListener<T> implements MessageListener {
+    @Autowired
+    private ObjectMapper objectMapper;
+    @Autowired
+    protected AnalyticsEventMapper analyticsEventMapper;
+    @Autowired
+    protected AnalyticsEventService analyticsEventService;
+    private final Class<T> eventType;
+
+    public AbstractEventListener(Class<T> eventType) {
+        this.eventType = eventType;
+    }
+
+    @Override
+    public void onMessage(Message message, byte[] pattern) {
+        try {
+            String chanel = new String(message.getChannel());
+            String body = new String(message.getBody());
+            log.info("Received message from channel {}: {}", chanel, body);
+            T event = objectMapper.readValue(body, eventType);
+            saveEvent(event);
+        } catch (JsonProcessingException e) {
+            log.error("Failed to process message from channel {}: {}", new String(message.getChannel()), new String(message.getBody()), e);
+            throw new RuntimeException("Error processing JSON message: " + e.getMessage(), e);
+        }
+    }
+
+    protected abstract void saveEvent(T event);
+}

--- a/src/main/java/faang/school/analytics/listener/PostViewEventListener.java
+++ b/src/main/java/faang/school/analytics/listener/PostViewEventListener.java
@@ -1,0 +1,20 @@
+package faang.school.analytics.listener;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class PostViewEventListener implements MessageListener {
+
+    @Override
+    public void onMessage(Message message, byte[] pattern) {
+        String chanel = new String(message.getChannel());
+        String body = new String(message.getBody());
+        log.info("Received message from channel {}: {}", chanel, body);
+
+
+    }
+}

--- a/src/main/java/faang/school/analytics/listener/PostViewEventListener.java
+++ b/src/main/java/faang/school/analytics/listener/PostViewEventListener.java
@@ -31,7 +31,7 @@ public class PostViewEventListener implements MessageListener {
             PostViewEvent postViewEvent = objectMapper.readValue(body, PostViewEvent.class);
             AnalyticsEvent analyticsEvent = analyticsEventMapper.toEntity(postViewEvent);
             analyticsEvent.setEventType(EventType.POST_VIEW);
-            analyticsEventService.saveEvent(analyticsEvent);
+            analyticsEventService.saveEvent(analyticsEventMapper.toDto(analyticsEvent));
         } catch (JsonProcessingException e) {
             log.error(e.getMessage());
             throw new RuntimeException(e);

--- a/src/main/java/faang/school/analytics/listener/PostViewEventListener.java
+++ b/src/main/java/faang/school/analytics/listener/PostViewEventListener.java
@@ -1,5 +1,13 @@
 package faang.school.analytics.listener;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import faang.school.analytics.dto.PostViewEvent;
+import faang.school.analytics.mapper.AnalyticsEventMapper;
+import faang.school.analytics.model.AnalyticsEvent;
+import faang.school.analytics.model.EventType;
+import faang.school.analytics.service.AnalyticsEventService;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.connection.Message;
 import org.springframework.data.redis.connection.MessageListener;
@@ -7,14 +15,26 @@ import org.springframework.stereotype.Component;
 
 @Slf4j
 @Component
+@RequiredArgsConstructor
 public class PostViewEventListener implements MessageListener {
+
+    private final ObjectMapper objectMapper;
+    private final AnalyticsEventMapper analyticsEventMapper;
+    private final AnalyticsEventService analyticsEventService;
 
     @Override
     public void onMessage(Message message, byte[] pattern) {
-        String chanel = new String(message.getChannel());
-        String body = new String(message.getBody());
-        log.info("Received message from channel {}: {}", chanel, body);
-
-
+        try {
+            String chanel = new String(message.getChannel());
+            String body = new String(message.getBody());
+            log.info("Received message from channel {}: {}", chanel, body);
+            PostViewEvent postViewEvent = objectMapper.readValue(body, PostViewEvent.class);
+            AnalyticsEvent analyticsEvent = analyticsEventMapper.toEntity(postViewEvent);
+            analyticsEvent.setEventType(EventType.POST_VIEW);
+            analyticsEventService.saveEvent(analyticsEvent);
+        } catch (JsonProcessingException e) {
+            log.error(e.getMessage());
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/src/main/java/faang/school/analytics/listener/PostViewEventListener.java
+++ b/src/main/java/faang/school/analytics/listener/PostViewEventListener.java
@@ -1,40 +1,22 @@
 package faang.school.analytics.listener;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import faang.school.analytics.dto.PostViewEvent;
-import faang.school.analytics.mapper.AnalyticsEventMapper;
 import faang.school.analytics.model.AnalyticsEvent;
 import faang.school.analytics.model.EventType;
-import faang.school.analytics.service.AnalyticsEventService;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.redis.connection.Message;
-import org.springframework.data.redis.connection.MessageListener;
 import org.springframework.stereotype.Component;
 
 @Slf4j
 @Component
-@RequiredArgsConstructor
-public class PostViewEventListener implements MessageListener {
-
-    private final ObjectMapper objectMapper;
-    private final AnalyticsEventMapper analyticsEventMapper;
-    private final AnalyticsEventService analyticsEventService;
+public class PostViewEventListener extends AbstractEventListener<PostViewEvent> {
+    public PostViewEventListener() {
+        super(PostViewEvent.class);
+    }
 
     @Override
-    public void onMessage(Message message, byte[] pattern) {
-        try {
-            String chanel = new String(message.getChannel());
-            String body = new String(message.getBody());
-            log.info("Received message from channel {}: {}", chanel, body);
-            PostViewEvent postViewEvent = objectMapper.readValue(body, PostViewEvent.class);
-            AnalyticsEvent analyticsEvent = analyticsEventMapper.toEntity(postViewEvent);
-            analyticsEvent.setEventType(EventType.POST_VIEW);
-            analyticsEventService.saveEvent(analyticsEventMapper.toDto(analyticsEvent));
-        } catch (JsonProcessingException e) {
-            log.error(e.getMessage());
-            throw new RuntimeException(e);
-        }
+    protected void saveEvent(PostViewEvent event) {
+        AnalyticsEvent analyticsEvent = analyticsEventMapper.toEntity(event);
+        analyticsEvent.setEventType(EventType.POST_VIEW);
+        analyticsEventService.saveEvent(analyticsEvent);
     }
 }

--- a/src/main/java/faang/school/analytics/mapper/AnalyticsEventMapper.java
+++ b/src/main/java/faang/school/analytics/mapper/AnalyticsEventMapper.java
@@ -1,0 +1,13 @@
+package faang.school.analytics.mapper;
+
+import faang.school.analytics.dto.PostViewEvent;
+import faang.school.analytics.model.AnalyticsEvent;
+import org.mapstruct.Mapper;
+import org.mapstruct.MappingConstants;
+import org.mapstruct.ReportingPolicy;
+
+@Mapper(unmappedTargetPolicy = ReportingPolicy.IGNORE,
+        componentModel = MappingConstants.ComponentModel.SPRING)
+public interface AnalyticsEventMapper {
+    AnalyticsEvent toEntity(PostViewEvent postViewEvent);
+}

--- a/src/main/java/faang/school/analytics/mapper/AnalyticsEventMapper.java
+++ b/src/main/java/faang/school/analytics/mapper/AnalyticsEventMapper.java
@@ -10,6 +10,4 @@ import org.mapstruct.ReportingPolicy;
         componentModel = MappingConstants.ComponentModel.SPRING)
 public interface AnalyticsEventMapper {
     AnalyticsEvent toEntity(PostViewEvent postViewEvent);
-
-    PostViewEvent toDto(AnalyticsEvent analyticsEvent);
 }

--- a/src/main/java/faang/school/analytics/mapper/AnalyticsEventMapper.java
+++ b/src/main/java/faang/school/analytics/mapper/AnalyticsEventMapper.java
@@ -10,4 +10,6 @@ import org.mapstruct.ReportingPolicy;
         componentModel = MappingConstants.ComponentModel.SPRING)
 public interface AnalyticsEventMapper {
     AnalyticsEvent toEntity(PostViewEvent postViewEvent);
+
+    PostViewEvent toDto(AnalyticsEvent analyticsEvent);
 }

--- a/src/main/java/faang/school/analytics/service/AnalyticsEventService.java
+++ b/src/main/java/faang/school/analytics/service/AnalyticsEventService.java
@@ -1,0 +1,20 @@
+package faang.school.analytics.service;
+
+import faang.school.analytics.model.AnalyticsEvent;
+import faang.school.analytics.repository.AnalyticsEventRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AnalyticsEventService {
+    private final AnalyticsEventRepository analyticsEventRepository;
+
+    @Transactional
+    public void saveEvent(AnalyticsEvent analyticsEvent) {
+        analyticsEventRepository.save(analyticsEvent);
+    }
+}

--- a/src/main/java/faang/school/analytics/service/AnalyticsEventService.java
+++ b/src/main/java/faang/school/analytics/service/AnalyticsEventService.java
@@ -1,20 +1,30 @@
 package faang.school.analytics.service;
 
+import faang.school.analytics.dto.PostViewEvent;
+import faang.school.analytics.mapper.AnalyticsEventMapper;
 import faang.school.analytics.model.AnalyticsEvent;
+import faang.school.analytics.model.EventType;
 import faang.school.analytics.repository.AnalyticsEventRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.List;
+
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class AnalyticsEventService {
     private final AnalyticsEventRepository analyticsEventRepository;
+    private final AnalyticsEventMapper analyticsEventMapper;
 
     @Transactional
-    public void saveEvent(AnalyticsEvent analyticsEvent) {
+    public void saveEvent(PostViewEvent postViewEvent) {
+        AnalyticsEvent analyticsEvent = analyticsEventMapper.toEntity(postViewEvent);
         analyticsEventRepository.save(analyticsEvent);
+        log.info("Event saved {}", analyticsEvent);
     }
 }

--- a/src/main/java/faang/school/analytics/service/AnalyticsEventService.java
+++ b/src/main/java/faang/school/analytics/service/AnalyticsEventService.java
@@ -1,29 +1,20 @@
 package faang.school.analytics.service;
 
-import faang.school.analytics.dto.PostViewEvent;
-import faang.school.analytics.mapper.AnalyticsEventMapper;
 import faang.school.analytics.model.AnalyticsEvent;
-import faang.school.analytics.model.EventType;
 import faang.school.analytics.repository.AnalyticsEventRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
-import java.util.Comparator;
-import java.util.List;
-
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class AnalyticsEventService {
     private final AnalyticsEventRepository analyticsEventRepository;
-    private final AnalyticsEventMapper analyticsEventMapper;
 
     @Transactional
-    public void saveEvent(PostViewEvent postViewEvent) {
-        AnalyticsEvent analyticsEvent = analyticsEventMapper.toEntity(postViewEvent);
+    public void saveEvent(AnalyticsEvent analyticsEvent) {
         analyticsEventRepository.save(analyticsEvent);
         log.info("Event saved {}", analyticsEvent);
     }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -24,7 +24,7 @@ spring:
       channel:
         profile-view: profile_view_channel
         post_view_event:
-          name: post_view_event_chanel
+          name: post_view_event_channel
 
 server:
   port: 8086

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,4 +1,6 @@
 spring:
+  main:
+    allow-bean-definition-overriding: true
   datasource:
     driver-class-name: org.postgresql.Driver
     url: jdbc:postgresql://localhost:5432/postgres
@@ -23,6 +25,10 @@ spring:
       host: localhost
       channel:
         profile-view: profile_view_channel
+        mentorship_requested_channel:
+          name: mentorship_requested_channel
+        post_view_event_channel:
+          name: post_view_event_channel
 
 server:
   port: 8086

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -23,6 +23,8 @@ spring:
       host: localhost
       channel:
         profile-view: profile_view_channel
+        post_view_event:
+          name: post_view_event_chanel
 
 server:
   port: 8086

--- a/src/test/java/faang/school/analytics/listener/PostViewEventListenerTest.java
+++ b/src/test/java/faang/school/analytics/listener/PostViewEventListenerTest.java
@@ -1,0 +1,101 @@
+package faang.school.analytics.listener;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import faang.school.analytics.dto.PostViewEvent;
+import faang.school.analytics.mapper.AnalyticsEventMapper;
+import faang.school.analytics.model.AnalyticsEvent;
+import faang.school.analytics.model.EventType;
+import faang.school.analytics.service.AnalyticsEventService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.connection.Message;
+
+import java.io.IOException;
+
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+
+@ExtendWith(MockitoExtension.class)
+public class PostViewEventListenerTest {
+    @InjectMocks
+    private PostViewEventListener postViewEventListener;
+    @Mock
+    private ObjectMapper objectMapper;
+    @Mock
+    private AnalyticsEventMapper analyticsEventMapper;
+    @Mock
+    private AnalyticsEventService analyticsEventService;
+    @Mock
+    private AnalyticsEvent analyticsEvent;
+    @Mock
+    private Message message;
+
+    private PostViewEvent event;
+    private String json;
+    private String invalidJson;
+    private String testChannel;
+    private byte[] body;
+    private byte[] invalidBody;
+    private byte[] channel;
+
+    @BeforeEach
+    void setUp() {
+        event = new PostViewEvent();
+        json = "{\"key\":\"value\"}";
+        invalidJson = "invalid_json";
+        testChannel = "test channel";
+        body = json.getBytes();
+        invalidBody = invalidJson.getBytes();
+        channel = testChannel.getBytes();
+    }
+
+    @Test
+    @DisplayName("Test of correct event saving.")
+    public void testSaveEvent() throws IOException {
+        when(message.getBody()).thenReturn(body);
+        when(message.getChannel()).thenReturn(channel);
+        when(objectMapper.readValue(any(String.class), eq(PostViewEvent.class))).thenReturn(event);
+        when(analyticsEventMapper.toEntity(event)).thenReturn(analyticsEvent);
+
+        postViewEventListener.onMessage(message, null);
+
+        verify(message).getChannel();
+        verify(message).getBody();
+        verify(objectMapper).readValue(any(String.class), eq(PostViewEvent.class));
+        verify(analyticsEventMapper).toEntity(event);
+        verify(analyticsEvent).setEventType(EventType.POST_VIEW);
+        verify(analyticsEventService).saveEvent(analyticsEvent);
+    }
+
+    @Test
+    @DisplayName("Test event saving with exception.")
+    public void testSaveEventWithException() throws JsonProcessingException {
+        when(message.getBody()).thenReturn(invalidBody);
+        when(message.getChannel()).thenReturn(channel);
+        when(objectMapper.readValue(any(String.class), eq(PostViewEvent.class))).thenThrow(new JsonProcessingException("Test exception") {});
+
+        Exception exception = assertThrows(RuntimeException.class, () ->
+            postViewEventListener.onMessage(message, null));
+
+        String expectedMessage = "Test exception";
+        String actualMessage = exception.getCause().getMessage();
+
+        assertTrue(actualMessage.contains(expectedMessage));
+
+        verify(message).getChannel();
+        verify(message).getBody();
+        verify(objectMapper).readValue(any(String.class), eq(PostViewEvent.class));
+    }
+}

--- a/src/test/java/faang/school/analytics/service/AnalyticsEventServiceTest.java
+++ b/src/test/java/faang/school/analytics/service/AnalyticsEventServiceTest.java
@@ -1,0 +1,47 @@
+package faang.school.analytics.service;
+
+import faang.school.analytics.dto.PostViewEvent;
+import faang.school.analytics.mapper.AnalyticsEventMapper;
+import faang.school.analytics.model.AnalyticsEvent;
+import faang.school.analytics.repository.AnalyticsEventRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class AnalyticsEventServiceTest {
+    @InjectMocks
+    private AnalyticsEventService analyticsEventService;
+    @Mock
+    private AnalyticsEventRepository analyticsEventRepository;
+    @Mock
+    private AnalyticsEventMapper analyticsEventMapper;
+    private AnalyticsEvent analyticsEvent;
+    private AnalyticsEvent analyticsEvent2;
+    private PostViewEvent postViewEvent;
+
+    @BeforeEach
+    void setUp() {
+        analyticsEvent = new AnalyticsEvent();
+        analyticsEvent2 = new AnalyticsEvent();
+        postViewEvent = new PostViewEvent();
+    }
+
+    @Test
+    @DisplayName("Save event.")
+    public void testSaveEvent() {
+        when(analyticsEventRepository.save(analyticsEvent)).thenReturn(analyticsEvent2);
+        when(analyticsEventMapper.toEntity(postViewEvent)).thenReturn(analyticsEvent);
+
+        analyticsEventService.saveEvent(postViewEvent);
+
+        verify(analyticsEventRepository).save(analyticsEvent);
+    }
+}

--- a/src/test/java/faang/school/analytics/service/AnalyticsEventServiceTest.java
+++ b/src/test/java/faang/school/analytics/service/AnalyticsEventServiceTest.java
@@ -38,9 +38,8 @@ public class AnalyticsEventServiceTest {
     @DisplayName("Save event.")
     public void testSaveEvent() {
         when(analyticsEventRepository.save(analyticsEvent)).thenReturn(analyticsEvent2);
-        when(analyticsEventMapper.toEntity(postViewEvent)).thenReturn(analyticsEvent);
 
-        analyticsEventService.saveEvent(postViewEvent);
+        analyticsEventService.saveEvent(analyticsEvent);
 
         verify(analyticsEventRepository).save(analyticsEvent);
     }


### PR DESCRIPTION
analytics_service должен собирать информацию о просмотрах поста пользователя/проекта другими юзерами в post_service:
Создать Spring-конфигурацию Redis топика и реализацию PostViewEventPublisher — отправителя события PostViewEvent в post_service. Туториал: [PubSub Messaging with Spring Data Redis | Baeldung](https://www.baeldung.com/spring-data-redis-pub-sub)  .
Отправлять событие PostViewEvent через PostViewEventPublisher в момент, когда пользователь просматривает пост другого пользователя — вызывает соответствующий эндпоинт. В событии содержатся: id поста; id автора; id юзера, который просматривает; дата и время просмотра. Пост может быть просмотрен и через эндпоинт получения конкретного поста, и когда пост попадает в список постов, которые получает пользователь.
В analytics_service создать конфигурацию слушателя эвентов PostViewEventListener для PostViewEvent, руководствуясь тем же тутором выше.
PostViewEventListener слушает события PostViewEvent и сохраняет информацию из этих событий с БД, используя AnalyticsEventService для выполнения логики сохранения и AnalyticsEvent для превращения PostViewEvent в сущность БД. Используем AnalyticsEventMapper для такого превращения.