### PR TITLE
BJS2-41467 completed without tests

### DIFF
--- a/src/main/java/faang/school/analytics/config/reddis/RedisConfiguration.java
+++ b/src/main/java/faang/school/analytics/config/reddis/RedisConfiguration.java
@@ -1,0 +1,72 @@
+package faang.school.analytics.config.reddis;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import faang.school.analytics.listener.mentorshipoffered.ProfileViewEventListener;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.jedis.JedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.data.redis.listener.adapter.MessageListenerAdapter;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+import org.springframework.data.util.Pair;
+
+import java.util.List;
+
+@Configuration
+@RequiredArgsConstructor
+public class RedisConfiguration {
+    private final RedisProperties redisProperties;
+    private final ObjectMapper objectMapper;
+    @Value("${spring.data.redis.host}")
+    private String host;
+    @Value("${spring.data.redis.port}")
+    private Integer port;
+
+    @Bean
+    JedisConnectionFactory jedisConnectionFactory() {
+        return new JedisConnectionFactory(new RedisStandaloneConfiguration(host, port));
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(jedisConnectionFactory());
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new GenericJackson2JsonRedisSerializer(objectMapper));
+        return template;
+    }
+
+    @Bean
+    public RedisMessageListenerContainer redisContainer(List<Pair<MessageListenerAdapter, ChannelTopic>> requesters,
+                                                        JedisConnectionFactory jedisConnectionFactory) {
+        RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+        container.setConnectionFactory(jedisConnectionFactory);
+        requesters.forEach(
+                (requester) -> container.addMessageListener(requester.getFirst(), requester.getSecond())
+        );
+        return container;
+    }
+
+    @Bean
+    public ChannelTopic profileViewTopic() {
+        return new ChannelTopic(redisProperties.getChannels().getProfileViewChannel().getName());
+    }
+
+    @Bean
+    public MessageListenerAdapter profileViewListener(ProfileViewEventListener profileViewEventListener) {
+        return new MessageListenerAdapter(profileViewEventListener);
+    }
+
+
+    @Bean
+    public Pair<MessageListenerAdapter, ChannelTopic> profileViewEventPair(MessageListenerAdapter profileViewMessageListener,
+                                                                               ChannelTopic profileViewEvent) {
+        return Pair.of(profileViewMessageListener, profileViewEvent);
+    }
+}

--- a/src/main/java/faang/school/analytics/config/reddis/RedisProperties.java
+++ b/src/main/java/faang/school/analytics/config/reddis/RedisProperties.java
@@ -1,0 +1,26 @@
+package faang.school.analytics.config.reddis;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "spring.data.redis")
+public class RedisProperties {
+    private Channels channels;
+
+    @Getter
+    @Setter
+    protected static class Channels {
+        private Channel profileViewChannel;
+
+        @Getter
+        @Setter
+        protected static class Channel {
+            private String name;
+        }
+    }
+}

--- a/src/main/java/faang/school/analytics/listener/AbstractEventListener.java
+++ b/src/main/java/faang/school/analytics/listener/AbstractEventListener.java
@@ -1,0 +1,29 @@
+package faang.school.analytics.listener;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.util.function.Consumer;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public abstract class AbstractEventListener<T> implements MessageListener {
+    protected final ObjectMapper objectMapper;
+
+    protected void handleEvent(Message message, Class<T> type, Consumer<T> consumer) {
+        try {
+            T event = objectMapper.readValue(message.getBody(), type);
+            consumer.accept(event);
+            log.info("Event processed: {} ", event);
+        } catch (IOException e) {
+            log.error("Failed to handle event: {}", type, e);
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/faang/school/analytics/listener/mentorshipoffered/ProfileViewEventListener.java
+++ b/src/main/java/faang/school/analytics/listener/mentorshipoffered/ProfileViewEventListener.java
@@ -1,0 +1,29 @@
+package faang.school.analytics.listener.mentorshipoffered;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import faang.school.analytics.listener.AbstractEventListener;
+import faang.school.analytics.model.dto.ProfileViewEvent;
+import faang.school.analytics.model.mapper.AnalyticsEventMapper;
+import faang.school.analytics.service.AnalyticsEventService;
+import jakarta.validation.constraints.NotNull;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ProfileViewEventListener extends AbstractEventListener<ProfileViewEvent> {
+
+
+ private final AnalyticsEventService analyticsEventService;
+ private final AnalyticsEventMapper analyticsEventMapper;
+
+    public ProfileViewEventListener(ObjectMapper objectMapper, AnalyticsEventService analyticsEventService, AnalyticsEventMapper analyticsEventMapper) {
+        super(objectMapper);
+        this.analyticsEventService = analyticsEventService;
+        this.analyticsEventMapper = analyticsEventMapper;
+    }
+    @Override
+    public void onMessage(@NotNull Message message, byte[] pattern) {
+        handleEvent(message, ProfileViewEvent.class, event
+                -> analyticsEventService.saveEvent(analyticsEventMapper.toEntityFromProfileViewEvent(event)));
+    }
+}

--- a/src/main/java/faang/school/analytics/model/dto/AnalyticsEventDto.java
+++ b/src/main/java/faang/school/analytics/model/dto/AnalyticsEventDto.java
@@ -1,10 +1,12 @@
 package faang.school.analytics.model.dto;
 
+import java.time.LocalDateTime;
+
 public record AnalyticsEventDto(
         long id,
         long receiverId,
         long actorId,
         String eventType,
-        String receivedAt
+        LocalDateTime receivedAt
 ) {
 }

--- a/src/main/java/faang/school/analytics/model/dto/ProfileViewEvent.java
+++ b/src/main/java/faang/school/analytics/model/dto/ProfileViewEvent.java
@@ -1,0 +1,7 @@
+package faang.school.analytics.model.dto;
+
+import java.time.LocalDateTime;
+
+public record ProfileViewEvent(long idRequester, long idUser, LocalDateTime createdTime) {
+
+}

--- a/src/main/java/faang/school/analytics/model/mapper/AnalyticsEventMapper.java
+++ b/src/main/java/faang/school/analytics/model/mapper/AnalyticsEventMapper.java
@@ -3,24 +3,28 @@ package faang.school.analytics.model.mapper;
 import faang.school.analytics.model.AnalyticsEvent;
 import faang.school.analytics.model.EventType;
 import faang.school.analytics.model.dto.AnalyticsEventDto;
+import faang.school.analytics.model.dto.ProfileViewEvent;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.Named;
-
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 
 
 @Mapper(componentModel = "spring")
 public interface AnalyticsEventMapper {
 
     @Mapping(source = "eventType", target = "eventType", qualifiedByName = "eventTypeToString")
-    @Mapping(source = "receivedAt", target = "receivedAt", qualifiedByName = "localDateTimeToString")
+    @Mapping(source = "receivedAt", target = "receivedAt")
     AnalyticsEventDto toDto(AnalyticsEvent event);
 
     @Mapping(source = "eventType", target = "eventType", qualifiedByName = "stringToEventType")
-    @Mapping(source = "receivedAt", target = "receivedAt", qualifiedByName = "stringToLocalDateTime")
+    @Mapping(source = "receivedAt", target = "receivedAt")
     AnalyticsEvent toEntity(AnalyticsEventDto dto);
+
+    @Mapping(target = "eventType", constant = "PROFILE_VIEW")
+    @Mapping(source = "createdTime", target = "receivedAt")
+    @Mapping(source = "idUser", target = "receiverId")
+    @Mapping(source = "idRequester", target = "actorId")
+    AnalyticsEvent toEntityFromProfileViewEvent(ProfileViewEvent profileViewEvent);
 
     @Named("eventTypeToString")
     static String eventTypeToString(EventType eventType) {
@@ -30,15 +34,5 @@ public interface AnalyticsEventMapper {
     @Named("stringToEventType")
     static EventType stringToEventType(String eventType) {
         return eventType != null ? EventType.valueOf(eventType) : null;
-    }
-
-    @Named("localDateTimeToString")
-    static String localDateTimeToString(LocalDateTime dateTime) {
-        return dateTime != null ? dateTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")) : null;
-    }
-
-    @Named("stringToLocalDateTime")
-    static LocalDateTime stringToLocalDateTime(String dateTime) {
-        return dateTime != null ? LocalDateTime.parse(dateTime, DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")) : null;
     }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -21,8 +21,9 @@ spring:
     redis:
       port: 6379
       host: localhost
-      channel:
-        profile-view: profile_view_channel
+      channels:
+        profileViewChannel:
+          name: profile_view_event_channel
 
 server:
   port: 8086

--- a/src/test/java/faang/school/analytics/mapper/AnalyticsEventMapperTest.java
+++ b/src/test/java/faang/school/analytics/mapper/AnalyticsEventMapperTest.java
@@ -3,6 +3,7 @@ package faang.school.analytics.mapper;
 import faang.school.analytics.model.AnalyticsEvent;
 import faang.school.analytics.model.EventType;
 import faang.school.analytics.model.dto.AnalyticsEventDto;
+import faang.school.analytics.model.dto.ProfileViewEvent;
 import faang.school.analytics.model.mapper.AnalyticsEventMapper;
 import org.junit.jupiter.api.Test;
 import org.mapstruct.factory.Mappers;
@@ -44,8 +45,6 @@ public class AnalyticsEventMapperTest {
                 "POST_COMMENT",
                 LocalDateTime.of(2023, 12, 10, 14, 30, 0)
         );
-
-
         AnalyticsEvent event = mapper.toEntity(dto);
 
         assertNotNull(event);
@@ -63,5 +62,30 @@ public class AnalyticsEventMapperTest {
 
         AnalyticsEvent event = mapper.toEntity(null);
         assertNull(event);
+    }
+
+
+    @Test
+    void testToEntityFromProfileViewEvent() {
+        LocalDateTime now = LocalDateTime.now();
+        ProfileViewEvent profileViewEvent = new ProfileViewEvent(202L, 101L, now);
+
+        AnalyticsEvent analyticsEvent = mapper.toEntityFromProfileViewEvent(profileViewEvent);
+        assertNotNull(analyticsEvent, "AnalyticsEvent should not be null after mapping.");
+
+        assertEquals(EventType.PROFILE_VIEW, analyticsEvent.getEventType(),
+                "eventType should be mapped as constant: PROFILE_VIEW.");
+        assertEquals(now, analyticsEvent.getReceivedAt(),
+                "receivedAt should match the createdTime of the source.");
+        assertEquals(101L, analyticsEvent.getReceiverId(),
+                "receiverId should match idUser from the source.");
+        assertEquals(202L, analyticsEvent.getActorId(),
+                "actorId should match idRequester from the source.");
+    }
+
+    @Test
+    void testToEntityFromProfileViewEvent_NullSource() {
+        AnalyticsEvent analyticsEvent = mapper.toEntityFromProfileViewEvent(null);
+        assertNull(analyticsEvent, "If source is null, result should be null (MapStruct default).");
     }
 }

--- a/src/test/java/faang/school/analytics/mapper/AnalyticsEventMapperTest.java
+++ b/src/test/java/faang/school/analytics/mapper/AnalyticsEventMapperTest.java
@@ -32,7 +32,7 @@ public class AnalyticsEventMapperTest {
         assertEquals(2L, dto.receiverId());
         assertEquals(3L, dto.actorId());
         assertEquals("POST_COMMENT", dto.eventType());
-        assertEquals("2023-12-10 14:30:00", dto.receivedAt());
+        assertEquals(LocalDateTime.of(2023, 12, 10, 14, 30, 0), dto.receivedAt());
     }
 
     @Test
@@ -42,7 +42,7 @@ public class AnalyticsEventMapperTest {
                 2L,
                 3L,
                 "POST_COMMENT",
-                "2023-12-10 14:30:00"
+                LocalDateTime.of(2023, 12, 10, 14, 30, 0)
         );
 
 


### PR DESCRIPTION
Задание
analytics_service должен собирать информацию о просмотрах профиля юзера другими юзерами в user_service:

Создать Spring-конфигурацию Redis топика и реализацию ProfileViewEventPublisher — отправителя события ProfileViewEvent в user_service. Туториал: [PubSub Messaging with Spring Data Redis | Baeldung](https://www.baeldung.com/spring-data-redis-pub-sub)  .

Отправлять событие ProfileViewEvent через ProfileViewEventPublisher в момент, когда пользователь просматривает профиль другого пользователя — вызывает соответствующий эндпоинт. В событии содержатся: id юзера; id юзера, который просматривает; дата и время просмотра.

В analytics_service создать конфигурацию слушателя эвентов ProfileViewEventListener для ProfileViewEvent, руководствуясь тем же тутором выше.

ProfileViewEventListener слушает события ProfileViewEvent и сохраняет информацию из этих событий с БД, используя AnalyticsEventService для выполнения логики сохранения и AnalyticsEvent для превращения ProfileViewEvent в сущность БД. Используем AnalyticsEventMapper для такого превращения.

Критерии приема
Сообщение о новом просмотре профиля отправляется в новый топик Redis из user_service.

Сообщение потребляется из нового топика в Redis в analytics_service.

Данные о событии сохраняются в БД в соответствующую таблицу analytics_event.

Всё покрыто unit-тестами.