### PR TITLE
 создана конфигурацию слушателя эвентов MentorshipRequestedEventListener

### DIFF
--- a/src/main/java/faang/school/analytics/AnalyticsServiceApp.java
+++ b/src/main/java/faang/school/analytics/AnalyticsServiceApp.java
@@ -9,7 +9,7 @@ import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.context.annotation.Bean;
 
 @SpringBootApplication
-@EnableFeignClients("school.faang.analytics.client")
+@EnableFeignClients("faang.school.analytics.client")
 public class AnalyticsServiceApp {
     public static void main(String[] args) {
         new SpringApplicationBuilder(AnalyticsServiceApp.class)

--- a/src/main/java/faang/school/analytics/config/RedisConfiguration.java
+++ b/src/main/java/faang/school/analytics/config/RedisConfiguration.java
@@ -2,9 +2,10 @@ package faang.school.analytics.config;
 
 import faang.school.analytics.listener.LikeEventListener;
 import faang.school.analytics.listener.MentorshipRequestedEventListener;
-import java.util.HashMap;
+import faang.school.analytics.listener.RedisChannelEventListeners;
 import java.util.Map;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
@@ -54,20 +55,18 @@ public class RedisConfiguration {
 
     @Bean
     public RedisMessageListenerContainer redisMessageListenerContainer(
-            Map<String, ChannelTopic> topics,
-            Map<String, MessageListenerAdapter> listeners) {
+            ApplicationContext context,
+            JedisConnectionFactory jedisConnectionFactory) {
 
-        Map<MessageListenerAdapter, ChannelTopic> listenersAndTopics = new HashMap<>();
         RedisMessageListenerContainer container = new RedisMessageListenerContainer();
-        container.setConnectionFactory(jedisConnectionFactory());
+        container.setConnectionFactory(jedisConnectionFactory);
 
-        topics.forEach((topicBeanName, topic) -> {
-            String listenerBeanName = topicBeanName.replace("Topic", "ListenerAdapter");
-            MessageListenerAdapter listener = listeners.get(listenerBeanName);
-            listenersAndTopics.put(listener, topic);
+        Map<String, RedisChannelEventListeners> listeners = context.getBeansOfType(RedisChannelEventListeners.class);
+
+        listeners.values().forEach(listener -> {
+            ChannelTopic topic = new ChannelTopic(listener.getChannel());
+            container.addMessageListener(listener, topic);
         });
-
-        listenersAndTopics.forEach(container::addMessageListener);
 
         return container;
     }

--- a/src/main/java/faang/school/analytics/config/RedisConfiguration.java
+++ b/src/main/java/faang/school/analytics/config/RedisConfiguration.java
@@ -1,6 +1,9 @@
 package faang.school.analytics.config;
 
 import faang.school.analytics.listener.LikeEventListener;
+import faang.school.analytics.listener.MentorshipRequestedEventListener;
+import java.util.HashMap;
+import java.util.Map;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -21,26 +24,51 @@ public class RedisConfiguration {
     @Value("${spring.data.redis.channel.like}")
     private String likeChannel;
 
+    @Value("${spring.data.redis.channel.mentorship-request}")
+    private String mentorshipRequestChannel;
+
     @Bean
     public JedisConnectionFactory jedisConnectionFactory() {
         return new JedisConnectionFactory(new RedisStandaloneConfiguration(redisHost, redisPort));
     }
 
     @Bean
-    public MessageListenerAdapter messageListener() {
-        return new MessageListenerAdapter(new LikeEventListener());
+    public MessageListenerAdapter likeEventListenerAdapter(LikeEventListener listener) {
+        return new MessageListenerAdapter(listener);
     }
 
     @Bean
-    ChannelTopic likeTopic() {
+    public MessageListenerAdapter mentorshipRequestedEventListenerAdapter(MentorshipRequestedEventListener listener) {
+        return new MessageListenerAdapter(listener);
+    }
+
+    @Bean
+    ChannelTopic likeEventTopic() {
         return new ChannelTopic(likeChannel);
     }
 
     @Bean
-    public RedisMessageListenerContainer redisContainer(MessageListenerAdapter listener) {
+    ChannelTopic mentorshipRequestedEventTopic() {
+        return new ChannelTopic(mentorshipRequestChannel);
+    }
+
+    @Bean
+    public RedisMessageListenerContainer redisMessageListenerContainer(
+            Map<String, ChannelTopic> topics,
+            Map<String, MessageListenerAdapter> listeners) {
+
+        Map<MessageListenerAdapter, ChannelTopic> listenersAndTopics = new HashMap<>();
         RedisMessageListenerContainer container = new RedisMessageListenerContainer();
         container.setConnectionFactory(jedisConnectionFactory());
-        container.addMessageListener(listener, likeTopic());
+
+        topics.forEach((topicBeanName, topic) -> {
+            String listenerBeanName = topicBeanName.replace("Topic", "ListenerAdapter");
+            MessageListenerAdapter listener = listeners.get(listenerBeanName);
+            listenersAndTopics.put(listener, topic);
+        });
+
+        listenersAndTopics.forEach(container::addMessageListener);
+
         return container;
     }
 }

--- a/src/main/java/faang/school/analytics/event/LikeEvent.java
+++ b/src/main/java/faang/school/analytics/event/LikeEvent.java
@@ -1,6 +1,8 @@
 package faang.school.analytics.event;
 
 
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -8,9 +10,19 @@ import lombok.Data;
 @Data
 @AllArgsConstructor
 public class LikeEvent {
+
+    @NotNull
+    @Positive
     private Long postId;
+
+    @NotNull
+    @Positive
     private Long authorId;
+
+    @NotNull
+    @Positive
     private Long likedByUserId;
+
     private LocalDateTime timestamp;
 }
 

--- a/src/main/java/faang/school/analytics/event/MentorshipRequestedEvent.java
+++ b/src/main/java/faang/school/analytics/event/MentorshipRequestedEvent.java
@@ -1,0 +1,13 @@
+package faang.school.analytics.event;
+
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+
+public record MentorshipRequestedEvent(
+        @NotNull
+        Long MentorshipRequestSenderId,
+        @NotNull
+        Long MentorId,
+        LocalDateTime timestamp
+) {
+}

--- a/src/main/java/faang/school/analytics/event/MentorshipRequestedEvent.java
+++ b/src/main/java/faang/school/analytics/event/MentorshipRequestedEvent.java
@@ -1,12 +1,15 @@
 package faang.school.analytics.event;
 
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 import java.time.LocalDateTime;
 
 public record MentorshipRequestedEvent(
         @NotNull
+        @Positive
         Long MentorshipRequestSenderId,
         @NotNull
+        @Positive
         Long MentorId,
         LocalDateTime timestamp
 ) {

--- a/src/main/java/faang/school/analytics/listener/LikeEventListener.java
+++ b/src/main/java/faang/school/analytics/listener/LikeEventListener.java
@@ -30,8 +30,7 @@ public class LikeEventListener implements RedisChannelEventListeners {
 
         try {
             LikeEvent likeEvent = objectMapper.readValue(message.getBody(), LikeEvent.class);
-            log.info("Parsed LikeEvent: {}", likeEvent);
-            
+            log.info("Parsed MentorshipRequestedEvent: {}", likeEvent);
             analyticsEventService.saveEvent(analyticsEventMapper.toLikeEntity(likeEvent));
         } catch (IOException e) {
             log.error("Failed to parse LikeEvent", e);

--- a/src/main/java/faang/school/analytics/listener/LikeEventListener.java
+++ b/src/main/java/faang/school/analytics/listener/LikeEventListener.java
@@ -5,25 +5,33 @@ import faang.school.analytics.event.LikeEvent;
 import faang.school.analytics.mapper.AnalyticsEventMapper;
 import faang.school.analytics.service.AnalyticsEventService;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.connection.Message;
-import org.springframework.data.redis.connection.MessageListener;
 import org.springframework.stereotype.Component;
 
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class LikeEventListener implements MessageListener, RedisChannelEventListeners {
+public class LikeEventListener implements RedisChannelEventListeners {
     private final ObjectMapper objectMapper;
     private final AnalyticsEventMapper analyticsEventMapper;
     private final AnalyticsEventService analyticsEventService;
 
     @Override
     public void onMessage(Message message, byte[] pattern) {
+        if (message == null || message.getBody() == null) {
+            log.warn("Received null message or empty body. Pattern: {}", pattern);
+            return;
+        }
+        String rawMessage = new String(message.getBody(), StandardCharsets.UTF_8);
+        log.info("Received raw Redis message: {}", rawMessage);
+
         try {
             LikeEvent likeEvent = objectMapper.readValue(message.getBody(), LikeEvent.class);
-            log.info("Received LikeEvent: {}", likeEvent);
+            log.info("Parsed LikeEvent: {}", likeEvent);
+            
             analyticsEventService.saveEvent(analyticsEventMapper.toLikeEntity(likeEvent));
         } catch (IOException e) {
             log.error("Failed to parse LikeEvent", e);

--- a/src/main/java/faang/school/analytics/listener/MentorshipRequestedEventListener.java
+++ b/src/main/java/faang/school/analytics/listener/MentorshipRequestedEventListener.java
@@ -1,7 +1,7 @@
 package faang.school.analytics.listener;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import faang.school.analytics.event.LikeEvent;
+import faang.school.analytics.event.MentorshipRequestedEvent;
 import faang.school.analytics.mapper.AnalyticsEventMapper;
 import faang.school.analytics.service.AnalyticsEventService;
 import java.io.IOException;
@@ -14,7 +14,7 @@ import org.springframework.stereotype.Component;
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class LikeEventListener implements MessageListener, RedisChannelEventListeners {
+public class MentorshipRequestedEventListener implements MessageListener, RedisChannelEventListeners {
     private final ObjectMapper objectMapper;
     private final AnalyticsEventMapper analyticsEventMapper;
     private final AnalyticsEventService analyticsEventService;
@@ -22,16 +22,16 @@ public class LikeEventListener implements MessageListener, RedisChannelEventList
     @Override
     public void onMessage(Message message, byte[] pattern) {
         try {
-            LikeEvent likeEvent = objectMapper.readValue(message.getBody(), LikeEvent.class);
-            log.info("Received LikeEvent: {}", likeEvent);
-            analyticsEventService.saveEvent(analyticsEventMapper.toLikeEntity(likeEvent));
+            MentorshipRequestedEvent event = objectMapper.readValue(message.getBody(), MentorshipRequestedEvent.class);
+            log.info("Received MentorshipRequestedEvent: {}", event);
+            analyticsEventService.saveEvent(analyticsEventMapper.toMentorshipEntity(event));
         } catch (IOException e) {
-            log.error("Failed to parse LikeEvent", e);
+            log.error("Failed to parse MentorshipRequestedEvent", e);
         }
     }
 
     @Override
     public String getChannel() {
-        return "like_channel";
+        return "mentorship_request";
     }
 }

--- a/src/main/java/faang/school/analytics/listener/MentorshipRequestedEventListener.java
+++ b/src/main/java/faang/school/analytics/listener/MentorshipRequestedEventListener.java
@@ -22,7 +22,7 @@ public class MentorshipRequestedEventListener implements RedisChannelEventListen
     @Override
     public void onMessage(Message message, byte[] pattern) {
         if (message == null || message.getBody() == null) {
-            log.warn("Received null message or empty body. Pattern: {}", pattern);
+            log.warn("Received null message or empty body.");
             return;
         }
         String rawMessage = new String(message.getBody(), StandardCharsets.UTF_8);

--- a/src/main/java/faang/school/analytics/listener/MentorshipRequestedEventListener.java
+++ b/src/main/java/faang/school/analytics/listener/MentorshipRequestedEventListener.java
@@ -5,25 +5,33 @@ import faang.school.analytics.event.MentorshipRequestedEvent;
 import faang.school.analytics.mapper.AnalyticsEventMapper;
 import faang.school.analytics.service.AnalyticsEventService;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.connection.Message;
-import org.springframework.data.redis.connection.MessageListener;
 import org.springframework.stereotype.Component;
 
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class MentorshipRequestedEventListener implements MessageListener, RedisChannelEventListeners {
+public class MentorshipRequestedEventListener implements RedisChannelEventListeners {
     private final ObjectMapper objectMapper;
     private final AnalyticsEventMapper analyticsEventMapper;
     private final AnalyticsEventService analyticsEventService;
 
     @Override
     public void onMessage(Message message, byte[] pattern) {
+        if (message == null || message.getBody() == null) {
+            log.warn("Received null message or empty body. Pattern: {}", pattern);
+            return;
+        }
+        String rawMessage = new String(message.getBody(), StandardCharsets.UTF_8);
+        log.info("Received raw Redis message: {}", rawMessage);
+
         try {
             MentorshipRequestedEvent event = objectMapper.readValue(message.getBody(), MentorshipRequestedEvent.class);
-            log.info("Received MentorshipRequestedEvent: {}", event);
+            log.info("Parsed MentorshipRequestedEvent: {}", event);
+
             analyticsEventService.saveEvent(analyticsEventMapper.toMentorshipEntity(event));
         } catch (IOException e) {
             log.error("Failed to parse MentorshipRequestedEvent", e);

--- a/src/main/java/faang/school/analytics/listener/RedisChannelEventListeners.java
+++ b/src/main/java/faang/school/analytics/listener/RedisChannelEventListeners.java
@@ -1,5 +1,7 @@
 package faang.school.analytics.listener;
 
-public interface RedisChannelEventListeners {
+import org.springframework.data.redis.connection.MessageListener;
+
+public interface RedisChannelEventListeners extends MessageListener {
     String getChannel();
 }

--- a/src/main/java/faang/school/analytics/listener/RedisChannelEventListeners.java
+++ b/src/main/java/faang/school/analytics/listener/RedisChannelEventListeners.java
@@ -1,0 +1,5 @@
+package faang.school.analytics.listener;
+
+public interface RedisChannelEventListeners {
+    String getChannel();
+}

--- a/src/main/java/faang/school/analytics/mapper/AnalyticsEventMapper.java
+++ b/src/main/java/faang/school/analytics/mapper/AnalyticsEventMapper.java
@@ -1,18 +1,23 @@
 package faang.school.analytics.mapper;
 
 import faang.school.analytics.event.LikeEvent;
+import faang.school.analytics.event.MentorshipRequestedEvent;
 import faang.school.analytics.model.AnalyticsEvent;
-import faang.school.analytics.model.EventType;
-import org.springframework.stereotype.Component;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.ReportingPolicy;
 
-@Component
-public class AnalyticsEventMapper {
-    public AnalyticsEvent toEntity(LikeEvent event) {
-        return AnalyticsEvent.builder()
-                .receiverId(event.getAuthorId())
-                .authorId(event.getLikedByUserId())
-                .eventType(EventType.POST_LIKE)
-                .receivedAt(event.getTimestamp())
-                .build();
-    }
+@Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
+public interface AnalyticsEventMapper {
+    @Mapping(target = "eventType", constant = "POST_LIKE")
+    @Mapping(source = "authorId", target = "authorId")
+    @Mapping(source = "likedByUserId", target = "receiverId")
+    @Mapping(source = "timestamp", target = "receivedAt")
+    AnalyticsEvent toLikeEntity(LikeEvent event);
+
+    @Mapping(target = "eventType", constant = "MENTORSHIP_REQUESTED")
+    @Mapping(source = "MentorshipRequestSenderId", target = "authorId")
+    @Mapping(source = "MentorId", target = "receiverId")
+    @Mapping(source = "timestamp", target = "receivedAt")
+    AnalyticsEvent toMentorshipEntity(MentorshipRequestedEvent event);
 }

--- a/src/main/java/faang/school/analytics/model/EventType.java
+++ b/src/main/java/faang/school/analytics/model/EventType.java
@@ -16,7 +16,8 @@ public enum EventType {
     GOAL_COMPLETED,
     ACHIEVEMENT_RECEIVED,
     PROFILE_APPEARED_IN_SEARCH,
-    PROJECT_APPEARED_IN_SEARCH;
+    PROJECT_APPEARED_IN_SEARCH,
+    MENTORSHIP_REQUESTED;
 
     public static EventType of(int type) {
         for (EventType eventType : EventType.values()) {

--- a/src/main/java/faang/school/analytics/service/AnalyticsEventService.java
+++ b/src/main/java/faang/school/analytics/service/AnalyticsEventService.java
@@ -1,6 +1,7 @@
 package faang.school.analytics.service;
 
 import faang.school.analytics.event.LikeEvent;
+import faang.school.analytics.event.MentorshipRequestedEvent;
 import faang.school.analytics.model.AnalyticsEvent;
 import faang.school.analytics.model.EventType;
 import faang.school.analytics.model.Interval;
@@ -10,7 +11,6 @@ import java.util.List;
 
 public interface AnalyticsEventService {
     void saveEvent(AnalyticsEvent event);
-    void saveLikeEvent(LikeEvent likeEvent);
 
     List<AnalyticsEvent> getAnalytics(
             long receiverId,

--- a/src/main/java/faang/school/analytics/service/AnalyticsEventServiceImpl.java
+++ b/src/main/java/faang/school/analytics/service/AnalyticsEventServiceImpl.java
@@ -1,36 +1,26 @@
 package faang.school.analytics.service;
 
-import faang.school.analytics.event.LikeEvent;
-import faang.school.analytics.mapper.AnalyticsEventMapper;
 import faang.school.analytics.model.AnalyticsEvent;
 import faang.school.analytics.model.EventType;
 import faang.school.analytics.model.Interval;
 import faang.school.analytics.repository.AnalyticsEventRepository;
+import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.List;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-
-import java.time.LocalDateTime;
-import java.util.Comparator;
-import java.util.List;
 
 @Service
 @Slf4j
 @RequiredArgsConstructor
 public class AnalyticsEventServiceImpl implements AnalyticsEventService {
     private final AnalyticsEventRepository analyticsEventRepository;
-    private final AnalyticsEventMapper analyticsEventMapper;
 
     @Override
     public void saveEvent(@NonNull AnalyticsEvent event) {
         analyticsEventRepository.save(event);
-    }
-
-    @Override
-    public void saveLikeEvent(LikeEvent likeEvent) {
-        AnalyticsEvent entity = analyticsEventMapper.toEntity(likeEvent);
-        analyticsEventRepository.save(entity);
     }
 
     @Override
@@ -58,10 +48,11 @@ public class AnalyticsEventServiceImpl implements AnalyticsEventService {
                 .sorted(Comparator.comparing(AnalyticsEvent::getReceivedAt).reversed())
                 .toList();
     }
+
     private List<AnalyticsEvent> filterEventsByDates(long receiverId,
-                                               EventType eventType,
-                                               LocalDateTime from,
-                                               LocalDateTime to
+                                                     EventType eventType,
+                                                     LocalDateTime from,
+                                                     LocalDateTime to
     ) {
         return analyticsEventRepository.findByReceiverIdAndEventType(receiverId, eventType)
                 .filter(event ->

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,7 +1,7 @@
 spring:
   datasource:
     driver-class-name: org.postgresql.Driver
-    url: jdbc:postgresql://localhost:5454/postgres
+    url: jdbc:postgresql://localhost:5432/postgres
     username: user
     password: password
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,7 +1,7 @@
 spring:
   datasource:
     driver-class-name: org.postgresql.Driver
-    url: jdbc:postgresql://localhost:5432/postgres
+    url: jdbc:postgresql://localhost:5454/postgres
     username: user
     password: password
 
@@ -24,6 +24,7 @@ spring:
       channel:
         profile-view: profile_view_channel
         like: like_channel
+        mentorship-request: mentorship_request
 
 server:
   port: 8086

--- a/src/test/java/faang/school/analytics/AnalyticsEventMapperTest.java
+++ b/src/test/java/faang/school/analytics/AnalyticsEventMapperTest.java
@@ -1,31 +1,53 @@
 package faang.school.analytics;
 
 import faang.school.analytics.event.LikeEvent;
+import faang.school.analytics.event.MentorshipRequestedEvent;
 import faang.school.analytics.mapper.AnalyticsEventMapper;
 import faang.school.analytics.model.AnalyticsEvent;
 import faang.school.analytics.model.EventType;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
 
 import static org.junit.Assert.assertEquals;
 
+@SpringBootTest
 public class AnalyticsEventMapperTest {
-    private final AnalyticsEventMapper mapper = new AnalyticsEventMapper();
+
+    @Autowired
+    private AnalyticsEventMapper mapper;
 
     @Test
     void toEntity_shouldMapAllFieldsCorrectly() {
-        LikeEvent likeEvent = new LikeEvent(
-                100L,
-                10L,
+        LikeEvent likeEvent = new LikeEvent(100L,
                 20L,
-                LocalDateTime.of(2024, 1, 1, 10, 15, 30)
-        );
+                10L,
+                LocalDateTime.of(2024, 1, 1, 10, 15, 30));
 
-        AnalyticsEvent result = mapper.toEntity(likeEvent);
+        AnalyticsEvent result = mapper.toLikeEntity(likeEvent);
 
-        assertEquals(10L, result.getReceiverId());
         assertEquals(20L, result.getAuthorId());
+        assertEquals(10L, result.getReceiverId());
         assertEquals(EventType.POST_LIKE, result.getEventType());
         assertEquals(LocalDateTime.of(2024, 1, 1, 10, 15, 30), result.getReceivedAt());
+    }
+
+    @Test
+    void toMentorshipEntity_shouldMapAllFieldsCorrectly() {
+
+        MentorshipRequestedEvent mentorshipEvent = new MentorshipRequestedEvent(
+                30L,
+                15L,
+                LocalDateTime.of(2024, 5, 10, 14, 0, 0)
+        );
+
+        AnalyticsEvent result = mapper.toMentorshipEntity(mentorshipEvent);
+
+        assertEquals(30L, result.getAuthorId());
+        assertEquals(15L, result.getReceiverId());
+        assertEquals(EventType.MENTORSHIP_REQUESTED, result.getEventType());
+        assertEquals(LocalDateTime.of(2024, 5, 10, 14, 0, 0),
+                result.getReceivedAt());
     }
 }

--- a/src/test/java/faang/school/analytics/AnalyticsEventServiceImplTest.java
+++ b/src/test/java/faang/school/analytics/AnalyticsEventServiceImplTest.java
@@ -1,12 +1,14 @@
 package faang.school.analytics;
 
-import faang.school.analytics.event.LikeEvent;
 import faang.school.analytics.mapper.AnalyticsEventMapper;
 import faang.school.analytics.model.AnalyticsEvent;
 import faang.school.analytics.model.EventType;
 import faang.school.analytics.model.Interval;
 import faang.school.analytics.repository.AnalyticsEventRepository;
 import faang.school.analytics.service.AnalyticsEventServiceImpl;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -16,11 +18,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.stream.Stream;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
@@ -64,16 +61,19 @@ public class AnalyticsEventServiceImplTest {
 
     @Test
     void saveLikeEventSuccessful() {
-        LikeEvent likeEvent = new LikeEvent(1L, 2L, 3L, LocalDateTime.now());
-        AnalyticsEvent mapped = new AnalyticsEvent(0L, 2L, 3L, EventType.POST_LIKE, likeEvent.getTimestamp());
+        AnalyticsEvent event = new AnalyticsEvent(
+                1L,
+                10L,
+                20L,
+                EventType.POST_LIKE,
+                LocalDateTime.now()
+        );
 
-        when(analyticsEventMapper.toEntity(likeEvent)).thenReturn(mapped);
+        analyticsEventService.saveEvent(event);
 
-        analyticsEventService.saveLikeEvent(likeEvent);
-
-        verify(analyticsEventMapper).toEntity(likeEvent);
-        verify(analyticsEventRepository).save(mapped);
+        verify(analyticsEventRepository).save(event);
     }
+
     @Test
     public void saveEventSuccessfullySaves() {
         AnalyticsEvent analyticsEvent = new AnalyticsEvent();


### PR DESCRIPTION
MentorshipRequestedEventListener слушает события MentorshipRequestedEvent и сохраняет информацию из этих событий с БД, используя AnalyticsEventService для выполнения логики сохранения и AnalyticsEvent для превращения MentorshipRequestedEvent в сущность БД. Используем AnalyticsEventMapper для такого превращения.